### PR TITLE
Implement avatars and previous messages

### DIFF
--- a/gitter.el
+++ b/gitter.el
@@ -392,9 +392,10 @@ learning how to make commandsnon-interactive."
 ;;; Commands
 
 ;;;###autoload
-(defun gitter ()
-  "Open a room."
-  (interactive)
+(defun gitter (&optional arg)
+  "Open a room.
+When ARG is non-nil, refresh `gitter--user-rooms' list."
+  (interactive "P")
   (unless (stringp gitter-token)
     (let* ((plist (car (auth-source-search :max 1 :host "gitter.im")))
            (k (plist-get plist :secret)))
@@ -403,7 +404,7 @@ learning how to make commandsnon-interactive."
         (user-error "`gitter-token' is not set.  \
 Please put this line in your ~/.authinfo or ~/.authinfo.gpg
 machine gitter.im password here-is-your-token"))))
-  (unless gitter--user-rooms
+  (when (or arg (not gitter--user-rooms))
     (setq gitter--user-rooms (gitter--request "GET" "/v1/rooms")))
   ;; FIXME Assuming room name is unique because of `completing-read'
   (let* ((rooms (mapcar (lambda (alist)

--- a/gitter.el
+++ b/gitter.el
@@ -411,6 +411,21 @@ machine gitter.im password here-is-your-token"))))
                           (let-alist alist
                             (cons .name .id)))
                         gitter--user-rooms))
+         (completion-extra-properties '(:annotation-function
+                                        (lambda (c)
+                                          (let* ((room (seq-find (lambda (r)
+                                                                   (rassoc c r))
+                                                                 gitter--user-rooms))
+                                                 (unread   (alist-get 'unreadItems room))
+                                                 (mentions (alist-get 'mentions room)))
+                                            (concat (when (/= unread 0)
+                                                      (propertize
+                                                       (format " unread: %s" unread)
+                                                       'face 'success))
+                                                     (when (/= mentions 0)
+                                                       (propertize
+                                                       (format " mentions %s" mentions)
+                                                       'face 'warning)))))))
          (name (completing-read "Open room: " rooms nil t))
          (id (cdr (assoc name rooms))))
     (unless (file-directory-p gitter--avatar-dir)


### PR DESCRIPTION
Thanks for the great work in this repo! @bryce-carson and me have decided to 'upgrade' this package and implement some nice extra/useful features.

This PR adds avatars to the prompts and makes gitter start with also showing a list of previous messages.
You could merge it already, because the added features are nice already, but I will probably 'redesign' things a little to add features like keeping track of unread messages etc.

Although the current PR comes from the master branch directly, I guess I will make use of feature branches from now on